### PR TITLE
fix: retry on network error

### DIFF
--- a/26-http-errors.html
+++ b/26-http-errors.html
@@ -9,7 +9,7 @@
       const [pokemon, setPokemon] = React.useState(null)
       const [error, setError] = React.useState(null)
 
-      React.useEffect(() => {
+      function loadPokemon() {
         if (!pokemonName) {
           return
         }
@@ -24,14 +24,16 @@
             setError(errorData)
           },
         )
-      }, [pokemonName])
+      }
+
+      React.useEffect(loadPokemon, [pokemonName])
 
       if (status === 'idle') {
         return 'Submit a pokemon'
       }
 
       if (status === 'rejected') {
-        return 'Oh no...'
+        return <pre> Something went wrong. <button onClick={loadPokemon}>Try again</button></pre>
       }
 
       if (status === 'pending') {
@@ -67,12 +69,13 @@
     }
 
     function fetchPokemon(name) {
+      const shouldFail = (Math.floor(Math.random() * 11) % 2) === 0
       const pokemonQuery = `
         query ($name: String) {
           pokemon(name: $name) {
             id
             number
-            name
+            ${shouldFail ? 'nam' : 'name'}
             attacks {
               special {
                 name


### PR DESCRIPTION
First of all great guide, thanks!

I was wondering what would happen if there is a network error but the user still wants to load the pokemon.

If there where a **network error** the `PokemonInfo `component will show _Oh no..._ But there is no way for the user to try to load the info again. The user will have to submit a different pokemon name and then it will have to submit the previous one.

This because the App state won't change if the user submit the same value, therefore it won't re-render the PokemonInfo component.

I did a little refactor to show behavior with a `Math.random` simulating and network error. 

And in order to fix the issue, I added a _Try Again_ button to the `PokemonInfo` component. It will call the same callback that is use by the effect of changing the pokemon's name. 
