### PR TITLE
Fix: Broken http request in example

### DIFF
--- a/26-http-errors.html
+++ b/26-http-errors.html
@@ -76,7 +76,7 @@
 
     function fetchPokemon(name) {
       const pokemonQuery = `
-        query ($name: String) {
+        query PokemonInfo($name: String) {
           pokemon(name: $name) {
             id
             number


### PR DESCRIPTION
Hello! Just a tiny fix I stumbled on while doing the course. 🙂 

The http request in `26-http-errors.html` is currently broken. It seems to me that the GraphQL query string is simply missing a query name.

This exact change was made to `25-http.html` in this commit: https://github.com/kentcdodds/beginners-guide-to-react/commit/e0cefaa459c9db8520984d8895483d30df9f552d, but seems to have been forgotten here.

Cheers! 🚀 