### PR TITLE
Added link of React Developer Roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,5 @@ Watch [The Beginner's Guide to React for free on egghead.io](https://kcd.im/begi
 If you wish to play with the finished examples, you can do so in this repository. It's not required to learn from the course (these are not exercises).
 
 To run the dev server, run the `start` file. If your operating system does not know how to run the "start" file, simply copy its contents into a command terminal to start the server.
+
+If you want to have a end to end structured guide to become a react developer then have a look at [React Developer Roadmap](https://roadmap.sh/react).


### PR DESCRIPTION
Hi @kentcdodds,

I came across your repository [beginners-guide-to-react](https://github.com/kentcdodds/beginners-guide-to-react) and found it to be a valuable resource for React enthusiasts.

While browsing through the repository, I noticed that it was missing links to any structured guides such as the famous ["React Developer Roadmap"](https://roadmap.sh/react). I took the initiative to submit a ["Pull Request"](https://github.com/kentcdodds/beginners-guide-to-react/pull/15) adding it in readme.md

Thank you for your time and effort in maintaining this valuable resource :)

Best,
Mouaaz